### PR TITLE
181 feat wp api

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,6 +22,9 @@ plugins:
   - import
 root: true
 rules:
+  max-len:
+    - 2
+    - code: 100
   "@typescript-eslint/ban-ts-comment": off
   import/order:
     - warn

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -122,7 +122,7 @@ class Abt_Admin_Page extends Abt_Base {
 	 * Custom endpoint for read.
 	 */
 	public function readable_api() {
-		$abt_options = get_option( 'abt_options' );
+		$abt_options = $this->get_abt_options();
 		return new WP_REST_Response( $abt_options, 200 );
 	}
 

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -24,8 +24,8 @@ class Abt_Admin_Page extends Abt_Base {
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'add_scripts' ] );
-		add_action( 'rest_api_init', [ $this, 'register' ] );
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->get_plugin_path() ), [ $this, 'add_settings_links' ] );
+		add_action( 'rest_api_init', [ $this, 'register_rest_api' ] );
 	}
 
 	/**
@@ -87,25 +87,27 @@ class Abt_Admin_Page extends Abt_Base {
 	}
 
 	/**
-	 * Set register.
+	 * Create custom endpoint.
 	 */
-	public function register() {
-		register_setting(
-			$this->get_option_group(),
-			$this->add_prefix( 'options' ),
+	public function register_rest_api() {
+		register_rest_route(
+			'admin-bar-tools/v1',
+			'/options',
 			[
-				'show_in_rest' => [
-					'schema' => [
-						'type'       => 'object',
-						'properties' => [
-							'items'   => [],
-							'locale'  => [],
-							'sc'      => [],
-							'version' => [],
-						],
-					],
-				],
-			],
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_options' ],
+				'permission_callback' => [ $this, 'get_wordpress_permission' ],
+			]
+		);
+
+		register_rest_route(
+			'admin-bar-tools/v1',
+			'/update',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'update_options' ],
+				'permission_callback' => [ $this, 'get_wordpress_permission' ],
+			]
 		);
 	}
 

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -91,7 +91,7 @@ class Abt_Admin_Page extends Abt_Base {
 	 */
 	public function register_rest_api() {
 		register_rest_route(
-			'admin-bar-tools/v1',
+			$this->get_api_namespace(),
 			'/options',
 			[
 				'methods'             => WP_REST_Server::READABLE,
@@ -101,7 +101,7 @@ class Abt_Admin_Page extends Abt_Base {
 		);
 
 		register_rest_route(
-			'admin-bar-tools/v1',
+			$this->get_api_namespace(),
 			'/update',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -105,7 +105,7 @@ class Abt_Admin_Page extends Abt_Base {
 			'/update',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'update_options' ],
+				'callback'            => [ $this, 'editable_api' ],
 				'permission_callback' => [ $this, 'get_wordpress_permission' ],
 			]
 		);
@@ -124,6 +124,37 @@ class Abt_Admin_Page extends Abt_Base {
 	public function readable_api() {
 		$abt_options = get_option( 'abt_options' );
 		return new WP_REST_Response( $abt_options, 200 );
+	}
+
+	/**
+	 * Custom endpoint for edit.
+	 *
+	 * @param WP_REST_Request $request WP_REST_Request object.
+	 */
+	public function editable_api( WP_REST_Request $request ) {
+		$abt_options = $this->get_abt_options();
+		$params      = $request->get_json_params();
+
+		if ( array_key_exists( 'items', $params ) ) {
+			$abt_options['items'] = $params['items'];
+		} elseif ( array_key_exists( 'sc', $params ) ) {
+			$abt_options['sc'] = $params['sc'];
+		} elseif ( array_key_exists( 'locale', $params ) ) {
+			$abt_options['locale'] = $params['locale'];
+		} else {
+			return new WP_Error( 'invalid_key', __( 'Required key does not exist', 'admin-bar-tools' ), [ 'status' => 404 ] );
+		}
+
+		$this->set_abt_options( $abt_options );
+
+		$response = new WP_REST_Response();
+		$response->set_status( 200 );
+		$response->set_data(
+			[
+				'params' => $params,
+			]
+		);
+		return $response;
 	}
 
 	/**

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -112,6 +112,13 @@ class Abt_Admin_Page extends Abt_Base {
 	}
 
 	/**
+	 * Return WordPress  administrator permission.
+	 */
+	public function get_wordpress_permission(): bool {
+		return current_user_can( 'administrator' );
+	}
+
+	/**
 	 * Settings page.
 	 */
 	public function abt_settings() {

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -147,14 +147,7 @@ class Abt_Admin_Page extends Abt_Base {
 
 		$this->set_abt_options( $abt_options );
 
-		$response = new WP_REST_Response();
-		$response->set_status( 200 );
-		$response->set_data(
-			[
-				'params' => $params,
-			]
-		);
-		return $response;
+		return new WP_REST_Response( $params, 200 );
 	}
 
 	/**

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -95,7 +95,7 @@ class Abt_Admin_Page extends Abt_Base {
 			'/options',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'get_options' ],
+				'callback'            => [ $this, 'readable_api' ],
 				'permission_callback' => [ $this, 'get_wordpress_permission' ],
 			]
 		);
@@ -116,6 +116,14 @@ class Abt_Admin_Page extends Abt_Base {
 	 */
 	public function get_wordpress_permission(): bool {
 		return current_user_can( 'administrator' );
+	}
+
+	/**
+	 * Custom endpoint for read.
+	 */
+	public function readable_api() {
+		$abt_options = get_option( 'abt_options' );
+		return new WP_REST_Response( $abt_options, 200 );
 	}
 
 	/**

--- a/class/class-abt-base.php
+++ b/class/class-abt-base.php
@@ -23,6 +23,7 @@ class Abt_Base {
 	protected const PLUGIN_NAME         = 'Admin Bar Tools';
 	protected const PLUGIN_FILE         = self::PLUGIN_SLUG . '.php';
 	protected const API_NAMESPACE       = self::PLUGIN_SLUG;
+	protected const API_VERSION         = 'v1';
 	protected const TABLE_NAME          = self::PREFIX;
 	protected const VERSION             = '1.4';
 	protected const OPTIONS_COLUMN_NAME = 'options';

--- a/class/class-abt-base.php
+++ b/class/class-abt-base.php
@@ -22,6 +22,7 @@ class Abt_Base {
 	protected const PLUGIN_SLUG         = 'admin-bar-tools';
 	protected const PLUGIN_NAME         = 'Admin Bar Tools';
 	protected const PLUGIN_FILE         = self::PLUGIN_SLUG . '.php';
+	protected const API_NAMESPACE       = self::PLUGIN_SLUG;
 	protected const TABLE_NAME          = self::PREFIX;
 	protected const VERSION             = '1.4';
 	protected const OPTIONS_COLUMN_NAME = 'options';

--- a/class/class-abt-base.php
+++ b/class/class-abt-base.php
@@ -249,7 +249,7 @@ class Abt_Base {
 	 * @param string $api_name    Plugin unique name.
 	 * @param string $api_version Plugin API version.
 	 */
-	protected function get_api_namespace( string $api_name = self::API_NAMESPACE, string $api_version = self::API_VERSION ) {
+	protected function get_api_namespace( string $api_name = self::API_NAME, string $api_version = self::API_VERSION ) {
 		return "${api_name}/${api_version}";
 	}
 

--- a/class/class-abt-base.php
+++ b/class/class-abt-base.php
@@ -22,7 +22,7 @@ class Abt_Base {
 	protected const PLUGIN_SLUG         = 'admin-bar-tools';
 	protected const PLUGIN_NAME         = 'Admin Bar Tools';
 	protected const PLUGIN_FILE         = self::PLUGIN_SLUG . '.php';
-	protected const API_NAMESPACE       = self::PLUGIN_SLUG;
+	protected const API_NAME            = self::PLUGIN_SLUG;
 	protected const API_VERSION         = 'v1';
 	protected const TABLE_NAME          = self::PREFIX;
 	protected const VERSION             = '1.4';

--- a/class/class-abt-base.php
+++ b/class/class-abt-base.php
@@ -243,6 +243,17 @@ class Abt_Base {
 	}
 
 	/**
+	 * Return WP-API parameter.
+	 * e.g. admin-bar-tools/v1
+	 *
+	 * @param string $api_name    Plugin unique name.
+	 * @param string $api_version Plugin API version.
+	 */
+	protected function get_api_namespace( string $api_name = self::API_NAMESPACE, string $api_version = self::API_VERSION ) {
+		return "${api_name}/${api_version}";
+	}
+
+	/**
 	 * Return option group.
 	 * Use register_setting.
 	 * e.g. admin-bar-tools-settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"@types/wordpress__components": "^19.3.0",
 				"@typescript-eslint/eslint-plugin": "^5.13.0",
 				"@typescript-eslint/parser": "^5.13.0",
+				"@wordpress/api-fetch": "^6.0.1",
 				"@wordpress/scripts": "^22.0.1",
 				"eslint-import-resolver-typescript": "^2.5.0",
 				"stylelint-order": "^5.0.0",
@@ -4676,6 +4677,20 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@wordpress/api-fetch": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.0.1.tgz",
+			"integrity": "sha512-rodFmGcnhI5gLKRueabLHiNrPpl/i+DCD23xg8/xs2Iyr47YFZZN4KB8WKaRVDxPZQJAB67IqMLs/h4U02HdmA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^4.3.1",
+				"@wordpress/url": "^3.4.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.1.tgz",
@@ -5574,6 +5589,19 @@
 			},
 			"peerDependencies": {
 				"stylelint": "^14.2"
+			}
+		},
+		"node_modules/@wordpress/url": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.4.1.tgz",
+			"integrity": "sha512-EeE/qCTe2wYxvEhH4ygV8CONX7j1aQaZF5LUg+QHZ+cnV5Bo8SkcLZdOHqczwvljqwVnKc+ybzQx/WLE+APNSw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"lodash": "^4.17.21"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/warning": {
@@ -23389,6 +23417,17 @@
 				"@wordpress/i18n": "^4.3.1"
 			}
 		},
+		"@wordpress/api-fetch": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.0.1.tgz",
+			"integrity": "sha512-rodFmGcnhI5gLKRueabLHiNrPpl/i+DCD23xg8/xs2Iyr47YFZZN4KB8WKaRVDxPZQJAB67IqMLs/h4U02HdmA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^4.3.1",
+				"@wordpress/url": "^3.4.1"
+			}
+		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.1.tgz",
@@ -24024,6 +24063,16 @@
 			"requires": {
 				"stylelint-config-recommended": "^6.0.0",
 				"stylelint-config-recommended-scss": "^5.0.2"
+			}
+		},
+		"@wordpress/url": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.4.1.tgz",
+			"integrity": "sha512-EeE/qCTe2wYxvEhH4ygV8CONX7j1aQaZF5LUg+QHZ+cnV5Bo8SkcLZdOHqczwvljqwVnKc+ybzQx/WLE+APNSw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.0",
+				"lodash": "^4.17.21"
 			}
 		},
 		"@wordpress/warning": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@types/wordpress__components": "^19.3.0",
 		"@typescript-eslint/eslint-plugin": "^5.13.0",
 		"@typescript-eslint/parser": "^5.13.0",
+		"@wordpress/api-fetch": "^6.0.1",
 		"@wordpress/scripts": "^22.0.1",
 		"eslint-import-resolver-typescript": "^2.5.0",
 		"stylelint-order": "^5.0.0",

--- a/src/component/molecules/Checkbox.tsx
+++ b/src/component/molecules/Checkbox.tsx
@@ -2,32 +2,23 @@ import { CheckboxControl } from '@wordpress/components';
 import { memo, useContext } from '@wordpress/element';
 
 import { apiContext } from '../..';
-import { useSetApi } from '../../hooks/useSetApi';
-import { apiType, locationItemsType, shortNameType } from '../../types/apiType';
+import { useChangeValue } from '../../hooks/useChangeValue';
+import { locationItemsType } from '../../types/apiType';
 
 export const Checkbox = memo( ( props: { itemKey: string } ) => {
-	const { apiData, setApiData } = useContext( apiContext );
+	const { apiData } = useContext( apiContext );
 	const { itemKey } = props;
-
-	const changeStatus = ( shortname: shortNameType ) => {
-		const newItem: apiType = JSON.parse( JSON.stringify( { ...apiData } ) );
-
-		newItem.abt_options.items[ shortname ].status = ! newItem.abt_options
-			.items[ shortname ].status;
-		setApiData( newItem );
-	};
-
-	useSetApi( itemKey, apiData.abt_options );
+	const changeValue = useChangeValue( itemKey );
 
 	return (
 		<>
-			{ Object.values( apiData.abt_options.items ).map(
+			{ Object.values( apiData.items ).map(
 				( item: locationItemsType ) => (
 					<CheckboxControl
 						key={ item.shortname }
 						label={ item.name }
 						checked={ item.status }
-						onChange={ () => changeStatus( item.shortname ) }
+						onChange={ () => changeValue( item.shortname ) }
 					/>
 				)
 			) }

--- a/src/component/molecules/Checkbox.tsx
+++ b/src/component/molecules/Checkbox.tsx
@@ -3,9 +3,9 @@ import { memo, useContext } from '@wordpress/element';
 
 import { apiContext } from '../..';
 import { useChangeValue } from '../../hooks/useChangeValue';
-import { locationItemsType } from '../../types/apiType';
+import { itemKeyType, locationItemsType } from '../../types/apiType';
 
-export const Checkbox = memo( ( props: { itemKey: string } ) => {
+export const Checkbox = memo( ( props: { itemKey: itemKeyType } ) => {
 	const { apiData } = useContext( apiContext );
 	const { itemKey } = props;
 	const changeValue = useChangeValue( itemKey );

--- a/src/component/molecules/Radio.tsx
+++ b/src/component/molecules/Radio.tsx
@@ -1,11 +1,12 @@
 import { RadioControl } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { itemKeyType } from 'types/apiType';
 
 import { apiContext } from '../..';
 import { useChangeValue } from '../../hooks/useChangeValue';
 
-export const Radio = ( props: { itemKey: string } ) => {
+export const Radio = ( props: { itemKey: itemKeyType } ) => {
 	const { apiData } = useContext( apiContext );
 	const { itemKey } = props;
 	const changeValue = useChangeValue( itemKey );

--- a/src/component/molecules/Radio.tsx
+++ b/src/component/molecules/Radio.tsx
@@ -3,25 +3,16 @@ import { useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { apiContext } from '../..';
-import { useSetApi } from '../../hooks/useSetApi';
-import { apiType } from '../../types/apiType';
+import { useChangeValue } from '../../hooks/useChangeValue';
 
 export const Radio = ( props: { itemKey: string } ) => {
-	const { apiData, setApiData } = useContext( apiContext );
+	const { apiData } = useContext( apiContext );
 	const { itemKey } = props;
-
-	const changeValue = ( value: number ) => {
-		const newItem: apiType = JSON.parse( JSON.stringify( { ...apiData } ) );
-
-		newItem.abt_options.sc = value;
-		setApiData( newItem );
-	};
-
-	useSetApi( itemKey, apiData.abt_options );
+	const changeValue = useChangeValue( itemKey );
 
 	return (
 		<RadioControl
-			selected={ apiData.abt_options.sc }
+			selected={ apiData.sc }
 			options={ [
 				{ label: __( "I don't use it.", 'admin-bar-tools' ), value: 0 },
 				{ label: __( 'Domain', 'admin-bar-tools' ), value: 1 },

--- a/src/component/molecules/Select.tsx
+++ b/src/component/molecules/Select.tsx
@@ -1,12 +1,13 @@
 import { SelectControl } from '@wordpress/components';
 import { memo, useContext } from '@wordpress/element';
 import { psiLocalesType } from 'types/LocaleType';
+import { itemKeyType } from 'types/apiType';
 
 import { apiContext } from '../..';
 import { useChangeValue } from '../../hooks/useChangeValue';
 import { psiLocales } from '../../lib/locale';
 
-export const Select = memo( ( props: { itemKey: string } ) => {
+export const Select = memo( ( props: { itemKey: itemKeyType } ) => {
 	const { apiData } = useContext( apiContext );
 	const { itemKey } = props;
 	const changeValue = useChangeValue( itemKey );

--- a/src/component/molecules/Select.tsx
+++ b/src/component/molecules/Select.tsx
@@ -3,37 +3,22 @@ import { memo, useContext } from '@wordpress/element';
 import { psiLocalesType } from 'types/LocaleType';
 
 import { apiContext } from '../..';
-import { useSetApi } from '../../hooks/useSetApi';
+import { useChangeValue } from '../../hooks/useChangeValue';
 import { psiLocales } from '../../lib/locale';
-import { apiType } from '../../types/apiType';
 
 export const Select = memo( ( props: { itemKey: string } ) => {
-	const { apiData, setApiData } = useContext( apiContext );
+	const { apiData } = useContext( apiContext );
 	const { itemKey } = props;
-
-	const changeLocale = ( value: string ) => {
-		const newItem: apiType = JSON.parse( JSON.stringify( { ...apiData } ) );
-
-		const psiUrl = {
-			url: `https://developers.google.com/speed/pagespeed/insights/?hl=${ value }&url=`,
-			adminurl: `https://developers.google.com/speed/pagespeed/insights/?hl=${ value }`,
-		};
-		newItem.abt_options.items.psi.url = psiUrl.url;
-		newItem.abt_options.items.psi.adminurl = psiUrl.adminurl;
-		newItem.abt_options.locale = value;
-		setApiData( newItem );
-	};
-
-	useSetApi( itemKey, apiData.abt_options );
+	const changeValue = useChangeValue( itemKey );
 
 	return (
 		<SelectControl
-			value={ apiData.abt_options.locale }
+			value={ apiData.locale }
 			options={ Object.values( psiLocales ).map( ( locale: psiLocalesType ) => ( {
 				label: locale.name,
 				value: locale.id,
 			} ) ) }
-			onChange={ ( value ) => changeLocale( value ) }
+			onChange={ ( value ) => changeValue( value ) }
 		/>
 	);
 } );

--- a/src/hooks/useChangeValue.ts
+++ b/src/hooks/useChangeValue.ts
@@ -1,0 +1,51 @@
+import { useContext } from '@wordpress/element';
+import { apiType, itemKeyType, shortNameType } from 'types/apiType';
+
+import { apiContext } from '../';
+import { shortNameList } from '../utils/constant';
+import { useSetApi } from './useSetApi';
+
+export const useChangeValue = ( itemKey: itemKeyType ) => {
+	const { apiData, setApiData } = useContext( apiContext );
+
+	const changeValue = ( value: string | number ) => {
+		const newItem: apiType = JSON.parse( JSON.stringify( { ...apiData } ) );
+
+		const isShortName = ( shortName: string ): shortName is shortNameType => {
+			return shortNameList.includes( shortName as shortNameType );
+		};
+
+		switch ( itemKey ) {
+			case 'items':
+				if ( typeof value === 'string' && isShortName( value ) ) {
+					newItem.items[ value ].status = ! newItem.items[ value ].status;
+				}
+				break;
+			case 'locale':
+				if ( typeof value === 'string' ) {
+					const url = 'https://developers.google.com/speed/pagespeed/insights/?hl=';
+					const psiUrl = {
+						url: `${ url }${ value }&url=`,
+						adminurl: `${ url }${ value }`,
+					};
+					newItem.items.psi.url = psiUrl.url;
+					newItem.items.psi.adminurl = psiUrl.adminurl;
+					newItem.locale = value;
+				}
+				break;
+			case 'sc':
+				if ( typeof value === 'number' ) {
+					newItem.sc = value;
+				}
+				break;
+			default:
+				break;
+		}
+
+		setApiData( newItem );
+	};
+
+	useSetApi( itemKey, apiData );
+
+	return changeValue;
+};

--- a/src/hooks/useGetApi.ts
+++ b/src/hooks/useGetApi.ts
@@ -1,23 +1,20 @@
 import { Dispatch, SetStateAction } from 'react';
 
-// @ts-ignore
-import api from '@wordpress/api';
+import apiFetch from '@wordpress/api-fetch';
 import { useEffect } from '@wordpress/element';
 
 import { apiType } from '../types/apiType';
 
 export const useGetApi = (
-	stateFunc: Dispatch< SetStateAction< apiType > >,
+	stateFunc: Dispatch< SetStateAction< Promise< apiType > > >,
 	setApiStatus: Dispatch< SetStateAction< boolean > >
 ) => {
 	useEffect( () => {
-		api.loadPromise.then( () => {
-			const model = new api.models.Settings();
-
-			model.fetch().then( ( res: apiType ) => {
-				stateFunc( res );
+		apiFetch<Promise<apiType>>( { path: '/abt/v1/options' } ).then( ( value ) => {
+			if ( value ) {
+				stateFunc( value );
 				setApiStatus( true );
-			} );
+			}
 		} );
 	}, [ stateFunc ] );
 };

--- a/src/hooks/useGetApi.ts
+++ b/src/hooks/useGetApi.ts
@@ -6,15 +6,13 @@ import { useEffect } from '@wordpress/element';
 import { apiType } from '../types/apiType';
 
 export const useGetApi = (
-	stateFunc: Dispatch< SetStateAction< Promise< apiType > > >,
+	stateFunc: Dispatch< SetStateAction< apiType > >,
 	setApiStatus: Dispatch< SetStateAction< boolean > >
 ) => {
 	useEffect( () => {
-		apiFetch<Promise<apiType>>( { path: '/abt/v1/options' } ).then( ( value ) => {
-			if ( value ) {
-				stateFunc( value );
-				setApiStatus( true );
-			}
+		apiFetch< apiType >( { path: '/abt/v1/options' } ).then( ( value ) => {
+			stateFunc( value );
+			setApiStatus( true );
 		} );
 	}, [ stateFunc ] );
 };

--- a/src/hooks/useGetApi.ts
+++ b/src/hooks/useGetApi.ts
@@ -10,7 +10,7 @@ export const useGetApi = (
 	setApiStatus: Dispatch< SetStateAction< boolean > >
 ) => {
 	useEffect( () => {
-		apiFetch< apiType >( { path: '/abt/v1/options' } ).then( ( value ) => {
+		apiFetch< apiType >( { path: '/admin-bar-tools/v1/options' } ).then( ( value ) => {
 			stateFunc( value );
 			setApiStatus( true );
 		} );

--- a/src/hooks/useSetApi.ts
+++ b/src/hooks/useSetApi.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import api from '@wordpress/api';
+import apiFetch from '@wordpress/api-fetch';
 import { useContext, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -21,25 +20,21 @@ export const useSetApi: useSetApiType = ( itemKey, value ) => {
 		if ( isFirstRender.current ) {
 			isFirstRender.current = false;
 		} else {
-			api.loadPromise.then( () => {
-				const model = new api.models.Settings( {
-					[ itemKey ]: value,
-				} );
-				const save = model.save();
+			setNoticeStatus( false );
+			clearTimeout( snackbarTimer );
 
-				setNoticeStatus( false );
-				clearTimeout( snackbarTimer );
-
-				save.success( () => {
-					setNoticeStatus( true );
-					setNoticeValue( 'abt_success' );
-					setNoticeMessage( __( 'Success.', 'admin-bar-tools' ) );
-				} );
-				save.error( () => {
-					setNoticeStatus( true );
-					setNoticeValue( 'abt_error' );
-					setNoticeMessage( __( 'Error.', 'admin-bar-tools' ) );
-				} );
+			apiFetch( {
+				path: '/admin-bar-tools/v1/update',
+				method: 'POST',
+				data: { [ itemKey ]: value[ itemKey ] },
+			} ).then( ( ) => {
+				setNoticeStatus( true );
+				setNoticeValue( 'abt_success' );
+				setNoticeMessage( __( 'Success.', 'admin-bar-tools' ) );
+			} ).catch( ( ) => {
+				setNoticeStatus( true );
+				setNoticeValue( 'abt_error' );
+				setNoticeMessage( __( 'Error.', 'admin-bar-tools' ) );
 			} );
 		}
 	}, [ apiData ] );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,7 +60,7 @@ const AdminPage = () => {
 						) }
 						classValue="select-display"
 					>
-						<Checkbox itemKey="abt_options" />
+						<Checkbox itemKey="items" />
 					</Items>
 					<Items
 						title={ __(
@@ -69,7 +69,7 @@ const AdminPage = () => {
 						) }
 						classValue="select-radio"
 					>
-						<Radio itemKey="abt_options" />
+						<Radio itemKey="sc" />
 					</Items>
 					<Items
 						title={ __(
@@ -78,7 +78,7 @@ const AdminPage = () => {
 						) }
 						classValue="select-location"
 					>
-						<Select itemKey="abt_options" />
+						<Select itemKey="locale" />
 					</Items>
 				</apiContext.Provider>
 			) : (

--- a/src/types/apiType.ts
+++ b/src/types/apiType.ts
@@ -1,5 +1,8 @@
 export type apiType = {
-	abt_options: abtOptionsType;
+	items: locationsType;
+	locale: string;
+	sc: number;
+	version: number;
 };
 
 export type abtOptionsType = {

--- a/src/types/apiType.ts
+++ b/src/types/apiType.ts
@@ -1,3 +1,5 @@
+import { shortNameList } from 'utils/constant';
+
 export type apiType = {
 	items: locationsType;
 	locale: string;
@@ -18,16 +20,7 @@ export type locationItemsType = {
 	order: number;
 };
 
-export type shortNameType =
-	| 'psi'
-	| 'lh'
-	| 'gsc'
-	| 'gc'
-	| 'gi'
-	| 'twitter'
-	| 'facebook'
-	| 'hatena'
-	| 'bi';
+export type shortNameType = typeof shortNameList[number];
 
 export type WPApiType< T > = {
 	[ key: string ]: {

--- a/src/types/apiType.ts
+++ b/src/types/apiType.ts
@@ -22,12 +22,6 @@ export type locationItemsType = {
 
 export type shortNameType = typeof shortNameList[number];
 
-export type WPApiType< T > = {
-	[ key: string ]: {
-		[ key: string ]: T;
-	};
-};
-
 export type itemKeyType = 'items' | 'locale' | 'sc' | 'version';
 
 export type useSetApiType = {

--- a/src/types/apiType.ts
+++ b/src/types/apiType.ts
@@ -6,15 +6,7 @@ export type apiType = {
 };
 
 export type locationsType = {
-	psi: locationItemsType;
-	lh: locationItemsType;
-	gsc: locationItemsType;
-	gc: locationItemsType;
-	gi: locationItemsType;
-	bi: locationItemsType;
-	twitter: locationItemsType;
-	facebook: locationItemsType;
-	hatena: locationItemsType;
+	[key in shortNameType]: locationItemsType;
 };
 
 export type locationItemsType = {

--- a/src/types/apiType.ts
+++ b/src/types/apiType.ts
@@ -28,6 +28,8 @@ export type WPApiType< T > = {
 	};
 };
 
+export type itemKeyType = 'items' | 'locale' | 'sc' | 'version';
+
 export type useSetApiType = {
-	( itemKey: string, value: apiType ): void;
+	( itemKey: itemKeyType, value: apiType ): void;
 };

--- a/src/types/apiType.ts
+++ b/src/types/apiType.ts
@@ -5,13 +5,6 @@ export type apiType = {
 	version: number;
 };
 
-export type abtOptionsType = {
-	items: locationsType;
-	locale: string;
-	sc: number;
-	version: number;
-};
-
 export type locationsType = {
 	psi: locationItemsType;
 	lh: locationItemsType;
@@ -51,5 +44,5 @@ export type WPApiType< T > = {
 };
 
 export type useSetApiType = {
-	( itemKey: string, value: abtOptionsType ): void;
+	( itemKey: string, value: apiType ): void;
 };

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -23,12 +23,10 @@ export const getApiInitValue = () => {
 	};
 
 	const abtOptions: apiType = {
-		abt_options: {
-			items: { ...locations },
-			locale: '',
-			sc: 0,
-			version: 0,
-		},
+		items: { ...locations },
+		locale: '',
+		sc: 0,
+		version: 0,
 	};
 
 	return abtOptions;

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,5 +1,17 @@
 import { apiType, locationItemsType, locationsType } from '../types/apiType';
 
+export const shortNameList = [
+	'psi',
+	'lh',
+	'gsc',
+	'gc',
+	'gi',
+	'bi',
+	'twitter',
+	'facebook',
+	'hatena',
+] as const;
+
 export const getApiInitValue = () => {
 	const locationItems: locationItemsType = {
 		name: '',


### PR DESCRIPTION
- refs #181 fix apiType
- refs #181 delete abtOptionsType,
- refs #181 fix abtOptions value
- refs #181 fix use @wordpress/api-fetch
- refs #181 fix apiFetch type
- refs #181 fix logic move useChangeValue hook.
- refs #181 fix itemKey value
- refs #181 fix locationsType use shortNameType
- refs #181 add shortNameList
- refs #181 fix shortNameType types use shortNameList
- refs #181 fix props -> itemKey type use itemKeyType
- refs #181 add itemKey Type
- refs #181 delete unused WPApiType
- refs #181 fix path
- refs #181 fix api -> use @wordpress/api-fetch
- refs #181 initial commit
- refs #181 add useChangeValue custom hooks
- refs #181 add rules -> max-len
- refs #181 add package -> @wordpress/api-fetch
- refs #181 add register_rest_api method, delete register method
- refs #181 add get_wordpress_permission method
- refs #181 add readble_api method
- refs #181 add editable_api method
- refs #181 fix readable_api abt_options
- refs #181 add API_NAMESPACE property
- refs #181 add API_VERSION property
- refs #181 fix API_NAMESPACE -> API_NAME
- refs #181 get_api_namespace method
- refs #181 fix get_api_namespace 1st arg default
- refs #181 register_rest_route 1st arg use get_api_namespace method
- refs #181 fix WP_REST_Response process
