### PR TITLE
391 fix unused wordpress constant

### DIFF
--- a/class/class-abt-base.php
+++ b/class/class-abt-base.php
@@ -73,7 +73,7 @@ class Abt_Base {
 	 * @param string $plugin_slug Plugin slug.
 	 */
 	protected function get_plugin_dir( string $plugin_slug = self::PLUGIN_SLUG ): string {
-		return WP_PLUGIN_DIR . '/' . $plugin_slug;
+		return dirname( plugin_dir_path( __FILE__ ), 2 ) . '/' . $plugin_slug;
 	}
 
 	/**

--- a/class/class-abt-base.php
+++ b/class/class-abt-base.php
@@ -55,7 +55,7 @@ class Abt_Base {
 	 * @param string $plugin_name Plugin name.
 	 */
 	protected function get_plugin_url( string $plugin_name = self::PLUGIN_SLUG ): string {
-		return WP_PLUGIN_URL . '/' . $plugin_name;
+		return content_url( 'plugins/' . $plugin_name );
 	}
 
 	/**

--- a/tests/AbtBaseTest.php
+++ b/tests/AbtBaseTest.php
@@ -39,18 +39,20 @@ class AbtBaseTest extends TestCase {
 
 	/**
 	 * TEST: return_plugin_url()
+	 *
+	 * @testWith [ "admin-bar-tools", null ]
+	 *           [ "send-chat-tools", "send-chat-tools" ]
+	 *
+	 * @param string $expected_plugin_name plugin name.
+	 * @param string $actual_plugin_name   plugin name.
 	 */
-	public function test_get_plugin_url() {
+	public function test_get_plugin_url( string $expected_plugin_name, ?string $actual_plugin_name ) {
 		$method = new ReflectionMethod( $this->instance, 'get_plugin_url' );
 		$method->setAccessible( true );
 
 		$this->assertSame(
-			WP_PLUGIN_URL . '/admin-bar-tools',
-			$method->invoke( $this->instance ),
-		);
-		$this->assertSame(
-			WP_PLUGIN_URL . '/send-chat-tools',
-			$method->invoke( $this->instance, 'send-chat-tools' ),
+			content_url( 'plugins/' . $expected_plugin_name ),
+			$actual_plugin_name ? $method->invoke( $this->instance, $actual_plugin_name ) : $method->invoke( $this->instance ),
 		);
 	}
 

--- a/tests/AbtBaseTest.php
+++ b/tests/AbtBaseTest.php
@@ -65,18 +65,20 @@ class AbtBaseTest extends TestCase {
 
 	/**
 	 * TEST: get_plugin_dir()
+	 *
+	 * @testWith [ "admin-bar-tools", null ]
+	 *           [ "send-chat-tools", "send-chat-tools" ]
+	 *
+	 * @param string $expected_plugin_name plugin name.
+	 * @param string $actual_plugin_name   plugin name.
 	 */
-	public function test_get_plugin_dir() {
+	public function test_get_plugin_dir( string $expected_plugin_name, ?string $actual_plugin_name ) {
 		$method = new ReflectionMethod( $this->instance, 'get_plugin_dir' );
 		$method->setAccessible( true );
 
 		$this->assertSame(
-			ABSPATH . 'wp-content/plugins/admin-bar-tools',
-			$method->invoke( $this->instance ),
-		);
-		$this->assertSame(
-			ABSPATH . 'wp-content/plugins/send-chat-tools',
-			$method->invoke( $this->instance, 'send-chat-tools' ),
+			ABSPATH . 'wp-content/plugins/' . $expected_plugin_name,
+			$actual_plugin_name ? $method->invoke( $this->instance, $actual_plugin_name ) : $method->invoke( $this->instance ),
 		);
 	}
 


### PR DESCRIPTION
- refs #391 fix unused WordPress Core constant, use content_url()
- refs #391 fix unused WordPress Core constant, use plugin_dir_path()
- refs #391 fix use testWith annotation, unused WordPress Core constant
