### PR TITLE
380 fix phpunit tests

### DIFF
--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -32,7 +32,7 @@ class Abt_Activate extends Abt_Base {
 	 *
 	 * @param array $args WordPress environment variables.
 	 */
-	public function check_environment( array $args ) {
+	public function check_environment( array $args, $environment_type = null ) {
 		$args['sslverify'] = match ( wp_get_environment_type() ) {
 			'development', 'local' => false,
 			'production', 'staging' => true,

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -32,7 +32,7 @@ class Abt_Activate extends Abt_Base {
 	 *
 	 * @param array $args WordPress environment variables.
 	 */
-	public function check_environment( $args ) {
+	public function check_environment( array $args ) {
 		$args['sslverify'] = match ( wp_get_environment_type() ) {
 			'development', 'local' => false,
 			'production', 'staging' => true,

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -30,10 +30,11 @@ class Abt_Activate extends Abt_Base {
 	/**
 	 * For development environments (development or local), set sslverify to false.
 	 *
-	 * @param array $args WordPress environment variables.
+	 * @param array       $args             WordPress environment variables.
+	 * @param string|null $environment_type WordPress environment type.
 	 */
-	public function check_environment( array $args, $environment_type = null ) {
-		$args['sslverify'] = match ( wp_get_environment_type() ) {
+	public function check_environment( array $args, ?string $environment_type = null ) {
+		$args['sslverify'] = match ( $environment_type ?? wp_get_environment_type() ) {
 			'development', 'local' => false,
 			'production', 'staging' => true,
 			default => true,

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -153,5 +153,6 @@ class Abt_Admin_Page extends Abt_Base {
 	 */
 	public function abt_settings(): void {
 		echo '<div id="' . esc_attr( $this->get_option_group() ) . '"></div>';
+		$this->console( WP_ENVIRONMENT_TYPE );
 	}
 }

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -31,8 +31,8 @@ class Abt_Admin_Page extends Abt_Base {
 	/**
 	 * Add WordPress menu.
 	 */
-	public function add_menu(): void {
-		add_options_page(
+	public function add_menu(): string {
+		return add_options_page(
 			$this->get_plugin_name(),
 			$this->get_plugin_name(),
 			'administrator',

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -153,6 +153,5 @@ class Abt_Admin_Page extends Abt_Base {
 	 */
 	public function abt_settings(): void {
 		echo '<div id="' . esc_attr( $this->get_option_group() ) . '"></div>';
-		$this->console( WP_ENVIRONMENT_TYPE );
 	}
 }

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -43,16 +43,30 @@ class AbtActivateTest extends TestCase {
 
 	/**
 	 * TEST: check_environment
+	 *
+	 * @testWith [ "development", false ]
+	 *           [ "local", false ]
+	 *           [ "production", true ]
+	 *           [ "staging", true ]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @param string $environment Environment type.
+	 * @param bool   $expected    Expected result.
 	 */
-	public function test_check_environment() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+	public function test_check_environment( string $environment, bool $expected ) {
+		$result = apply_filters( 'http_request_args', [ 'sslverify' => $environment ] );
+		define( 'WP_ENVIRONMENT_TYPE', $environment );
+
+		$this->assertSame( $expected, $this->instance->check_environment( $result )['sslverify'] );
 	}
 
 	/**
 	 * TEST: check_abt_options_column_exists
 	 */
 	public function test_check_abt_options_column_exists() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+		$this->markTestIncomplete( 'This test is incomplete . ' );
 	}
 
 	/**

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -49,17 +49,13 @@ class AbtActivateTest extends TestCase {
 	 *           [ "production", true ]
 	 *           [ "staging", true ]
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 *
 	 * @param string $environment Environment type.
 	 * @param bool   $expected    Expected result.
 	 */
 	public function test_check_environment( string $environment, bool $expected ) {
-		$result = apply_filters( 'http_request_args', [ 'sslverify' => $environment ] );
-		define( 'WP_ENVIRONMENT_TYPE', $environment );
+		$result = apply_filters( 'http_request_args', [ 'sslverify' => false ] );
 
-		$this->assertSame( $expected, $this->instance->check_environment( $result )['sslverify'] );
+		$this->assertSame( $expected, $this->instance->check_environment( $result, $environment )['sslverify'] );
 	}
 
 	/**

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -48,14 +48,22 @@ class AbtActivateTest extends TestCase {
 	 *           [ "local", false ]
 	 *           [ "production", true ]
 	 *           [ "staging", true ]
+	 *           [ null, null ]
 	 *
 	 * @param string $environment Environment type.
 	 * @param bool   $expected    Expected result.
 	 */
-	public function test_check_environment( string $environment, bool $expected ) {
+	public function test_check_environment( ?string $environment, ?bool $expected ) {
 		$result = apply_filters( 'http_request_args', [ 'sslverify' => false ] );
 
-		$this->assertSame( $expected, $this->instance->check_environment( $result, $environment )['sslverify'] );
+		if ( ! is_null( $environment ) ) {
+			$this->assertSame( $expected, $this->instance->check_environment( $result, $environment )['sslverify'] );
+		} else {
+			$this->assertSame(
+				in_array( wp_get_environment_type(), [ 'production', 'staging' ], true ),
+				$this->instance->check_environment( args: $result )['sslverify']
+			);
+		}
 	}
 
 	/**

--- a/tests/AbtAddAdminBarTest.php
+++ b/tests/AbtAddAdminBarTest.php
@@ -101,8 +101,23 @@ class AbtAddAdminBarTest extends TestCase {
 
 	/**
 	 * TEST: add_theme_support_link()
+	 *
+	 * @testWith [ "abt_theme_support", "abt" ]
+	 *           [ "official", "abt_theme_support" ]
+	 *           [ "manual", "abt_theme_support" ]
+	 *           [ "forum", "abt_theme_support" ]
+	 *
+	 * @param string $id     node id.
+	 * @param string $parent node parent.
 	 */
-	public function test_add_theme_support_link() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+	public function test_add_theme_support_link( string $id, string $parent ) {
+		$wp_admin_bar = new WP_Admin_Bar();
+		$wp_admin_bar->initialize();
+
+		switch_theme( 'cocoon-master' );
+		$this->instance->add_theme_support_link( $wp_admin_bar );
+
+		$this->assertArrayHasKey( $id, $wp_admin_bar->get_nodes() );
+		$this->assertSame( $parent, $wp_admin_bar->get_node( $id )->parent );
 	}
 }

--- a/tests/AbtAdminPageTest.php
+++ b/tests/AbtAdminPageTest.php
@@ -39,7 +39,22 @@ class AbtAdminPageTest extends TestCase {
 	 * TEST: add_menu()
 	 */
 	public function test_add_menu() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+		$abt_base                 = new Abt_Base();
+		$abt_base_get_plugin_name = new ReflectionMethod( $abt_base, 'get_plugin_name' );
+		$abt_base_get_plugin_name->setAccessible( true );
+
+		$abt_base_add_prefix = new ReflectionMethod( $abt_base, 'add_prefix' );
+		$abt_base_add_prefix->setAccessible( true );
+
+		$expected = add_options_page(
+			$abt_base_get_plugin_name->invoke( $abt_base ),
+			$abt_base_get_plugin_name->invoke( $abt_base ),
+			'administrator',
+			'admin-bar-tools',
+			$abt_base_add_prefix->invoke( $abt_base, 'settings' ),
+		);
+
+		$this->assertSame( 'admin_page_admin-bar-tools', $expected );
 	}
 
 	/**


### PR DESCRIPTION
- refs #380 add arg type
- refs #380 add environment_type -> arg
- refs #380 fix sslverify -> use false, add 2nd arg
- refs #380 remove unused output
- refs #380 add use default WP_ENVIRONMENT_TYPE test
- refs #380 add environment_type
- refs #380 fix implementation test_add_menu
- refs #380 fix return type, add execution result of add_options_page function
- refs #380 fix implementation test_add_theme_support_link method
