### PR TITLE
393 fix phpunit ci use module

### DIFF
--- a/.github/actions/node_modules-dependencies/action.yml
+++ b/.github/actions/node_modules-dependencies/action.yml
@@ -1,0 +1,27 @@
+name: Cache node_modules dependencies
+description: Cache node_modules directories and make them reusable
+
+inputs:
+  cache_tag:
+    description: Cache tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Cache node_modules dependencies
+      id: cache_node_modules_dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.workspace }}/node_modules
+        key: ${{ runner.os }}-node_modules-dependencies-${{ inputs.cache_tag }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node_modules-dependencies-${{ env.cache_tag }}-
+          ${{ runner.os }}-node_modules-dependencies-
+          ${{ runner.os }}
+          
+    - name: Install npm packages
+      shell: bash
+      if: steps.cache_node_modules_dependencies.outputs.cache-hit != 'true'
+      run: npm ci --ignore-scripts
+      

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -1,0 +1,18 @@
+name: Setup Node.js
+description: Setup Node.js
+
+inputs:
+  node-version:
+    description: 'The version of Node.js to use'
+    required: false
+    default: 18
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: ${{ github.workspace }}/package-lock.json

--- a/.github/actions/vendor-dependencies/action.yml
+++ b/.github/actions/vendor-dependencies/action.yml
@@ -1,0 +1,26 @@
+name: Cache vendor dependencies
+description: Cache vendor directories and make them reusable
+
+inputs:
+  cache_tag:
+    description: Cache tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Cache vendor dependencies
+      id: cache_vendor_dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.workspace }}/vendor
+        key: ${{ runner.os }}-vendor-dependencies-${{ inputs.cache_tag }}-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-vendor-dependencies-${{ env.cache_tag }}-
+          ${{ runner.os }}-vendor-dependencies-
+          ${{ runner.os }}
+
+    - name: Install composer packages
+      shell: bash
+      if: steps.cache_vendor_dependencies.outputs.cache-hit != 'true'
+      run: composer install --prefer-dist --no-scripts --no-progress

--- a/.github/workflows/deploy-wordpress-svn.yml
+++ b/.github/workflows/deploy-wordpress-svn.yml
@@ -19,20 +19,10 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
 
-      - name: Cache npm packages
-        id: npm_cache
-        uses: actions/cache@v3
+      - name: Install npm packages & cache node_modules directory
+        uses: ./.github/actions/node_modules-dependencies
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.CACHE_TAG }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-${{ env.CACHE_TAG }}-
-            ${{ runner.os }}-composer-
-            ${{ runner.os }}
-
-      - name: Install dependencies
-        if: steps.npm_cache.outputs.cache-hit != 'true'
-        run: npm ci --ignore-scripts
+          cache_tag: ${{ env.CACHE_TAG }}
 
       - name: JS build
         run: npm run build

--- a/.github/workflows/deploy-wordpress-svn.yml
+++ b/.github/workflows/deploy-wordpress-svn.yml
@@ -17,9 +17,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
+        uses: ./.github/actions/setup-nodejs
 
       - name: Cache npm packages
         id: npm_cache

--- a/.github/workflows/jslint.yml
+++ b/.github/workflows/jslint.yml
@@ -17,9 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
+        uses: ./.github/actions/setup-nodejs
 
       - name: Cache npm
         id: npm_cache

--- a/.github/workflows/jslint.yml
+++ b/.github/workflows/jslint.yml
@@ -19,20 +19,10 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
 
-      - name: Cache npm
-        id: npm_cache
-        uses: actions/cache@v3
+      - name: Install npm packages & cache node_modules directory
+        uses: ./.github/actions/node_modules-dependencies
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.CACHE_TAG }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-${{ env.CACHE_TAG }}-
-            ${{ runner.os }}-composer-
-            ${{ runner.os }}
-
-      - name: Install dependencies
-        if: steps.npm_cache.outputs.cache-hit != 'true'
-        run: npm ci --ignore-scripts
+          cache_tag: ${{ env.CACHE_TAG }}
 
       - name: ESLint
         run: npm run lint:js

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,6 +23,9 @@ jobs:
           cache_tag: ${{ env.CACHE_TAG }}
 
       - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -51,6 +54,9 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, xdebug, dom
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
 
       - name: Install composer packages & cache vendor directory
         uses: ./.github/actions/vendor-dependencies

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,13 +24,6 @@ jobs:
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'npm'
-          cache-dependency-path: ${{ github.workspace }}/package-lock.json
       
       - name: Install npm packages & cache node_modules
         uses: ./.github/actions/node_modules-dependencies

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
       
-      - name: Install npm packages & cache node_modules
+      - name: Install npm packages & cache node_modules directory
         uses: ./.github/actions/node_modules-dependencies
         with:
           cache_tag: ${{ env.CACHE_TAG }}
@@ -56,7 +56,7 @@ jobs:
         with:
           cache_tag: ${{ env.CACHE_TAG }}
 
-      - name: Install npm packages & cache node_modules
+      - name: Install npm packages & cache node_modules directory
         uses: ./.github/actions/node_modules-dependencies
         with:
           cache_tag: ${{ env.CACHE_TAG }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,27 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cache vendor dependencies
-        id: vendor_dependencies
-        uses: actions/cache@v3
+      - name: Install composer packages & cache vendor directory
+        uses: ./.github/actions/vendor-dependencies
         with:
-          path: ${{ github.workspace }}/vendor
-          key: ${{ runner.os }}-vendor_dependencies-${{ env.CACHE_TAG }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-vendor_dependencies-${{ env.CACHE_TAG }}-
-            ${{ runner.os }}-vendor_dependencies-
-            ${{ runner.os }}
-
-      - name: Cache node_modules dependencies
-        id: node_modules_dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/node_modules
-          key: ${{ runner.os }}-node_modules_dependencies-${{ env.CACHE_TAG }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules_dependencies-${{ env.CACHE_TAG }}-
-            ${{ runner.os }}-node_modules_dependencies-
-            ${{ runner.os }}
+          cache_tag: ${{ env.CACHE_TAG }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -45,14 +28,11 @@ jobs:
           node-version: 18
           cache: 'npm'
           cache-dependency-path: ${{ github.workspace }}/package-lock.json
-
-      - name: Install composer packages
-        if: steps.vendor_dependencies.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-scripts --no-progress
-
-      - name: Install npm packages
-        if: steps.node_modules_dependencies.outputs.cache-hit != 'true'
-        run: npm ci --ignore-scripts
+      
+      - name: Install npm packages & cache node_modules
+        uses: ./.github/actions/node_modules-dependencies
+        with:
+          cache_tag: ${{ env.CACHE_TAG }}
 
   test:
     name: PHPUnit
@@ -72,35 +52,15 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, xdebug, dom
 
-      - name: Cache vendor dependencies
-        id: vendor_dependencies
-        uses: actions/cache@v3
+      - name: Install composer packages & cache vendor directory
+        uses: ./.github/actions/vendor-dependencies
         with:
-          path: ${{ github.workspace }}/vendor
-          key: ${{ runner.os }}-vendor_dependencies-${{ env.CACHE_TAG }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-vendor_dependencies-${{ env.CACHE_TAG }}-
-            ${{ runner.os }}-vendor_dependencies-
-            ${{ runner.os }}
+          cache_tag: ${{ env.CACHE_TAG }}
 
-      - name: Cache node_modules dependencies
-        id: node_modules_dependencies
-        uses: actions/cache@v3
+      - name: Install npm packages & cache node_modules
+        uses: ./.github/actions/node_modules-dependencies
         with:
-          path: ${{ github.workspace }}/node_modules
-          key: ${{ runner.os }}-node_modules_dependencies-${{ env.CACHE_TAG }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules_dependencies-${{ env.CACHE_TAG }}-
-            ${{ runner.os }}-node_modules_dependencies-
-            ${{ runner.os }}
-
-      - name: Install composer packages
-        if: steps.vendor_dependencies.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-scripts --no-progress
-
-      - name: Install npm packages
-        if: steps.node_modules_dependencies.outputs.cache-hit != 'true'
-        run: npm ci --ignore-scripts
+          cache_tag: ${{ env.CACHE_TAG }}
 
       - name: TypeScript compile
         run: npm run build

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -32,7 +32,7 @@ class Abt_Activate extends Abt_Base {
 	 *
 	 * @param array $args WordPress environment variables.
 	 */
-	public function check_environment( array $args ) {
+	public function check_environment( array $args, $environment_type = null ) {
 		$args['sslverify'] = match ( wp_get_environment_type() ) {
 			'development', 'local' => false,
 			'production', 'staging' => true,

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -32,7 +32,7 @@ class Abt_Activate extends Abt_Base {
 	 *
 	 * @param array $args WordPress environment variables.
 	 */
-	public function check_environment( $args ) {
+	public function check_environment( array $args ) {
 		$args['sslverify'] = match ( wp_get_environment_type() ) {
 			'development', 'local' => false,
 			'production', 'staging' => true,

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -30,10 +30,11 @@ class Abt_Activate extends Abt_Base {
 	/**
 	 * For development environments (development or local), set sslverify to false.
 	 *
-	 * @param array $args WordPress environment variables.
+	 * @param array       $args             WordPress environment variables.
+	 * @param string|null $environment_type WordPress environment type.
 	 */
-	public function check_environment( array $args, $environment_type = null ) {
-		$args['sslverify'] = match ( wp_get_environment_type() ) {
+	public function check_environment( array $args, ?string $environment_type = null ) {
+		$args['sslverify'] = match ( $environment_type ?? wp_get_environment_type() ) {
 			'development', 'local' => false,
 			'production', 'staging' => true,
 			default => true,

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -153,5 +153,6 @@ class Abt_Admin_Page extends Abt_Base {
 	 */
 	public function abt_settings(): void {
 		echo '<div id="' . esc_attr( $this->get_option_group() ) . '"></div>';
+		$this->console( WP_ENVIRONMENT_TYPE );
 	}
 }

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -31,8 +31,8 @@ class Abt_Admin_Page extends Abt_Base {
 	/**
 	 * Add WordPress menu.
 	 */
-	public function add_menu(): void {
-		add_options_page(
+	public function add_menu(): string {
+		return add_options_page(
 			$this->get_plugin_name(),
 			$this->get_plugin_name(),
 			'administrator',

--- a/class/class-abt-admin-page.php
+++ b/class/class-abt-admin-page.php
@@ -153,6 +153,5 @@ class Abt_Admin_Page extends Abt_Base {
 	 */
 	public function abt_settings(): void {
 		echo '<div id="' . esc_attr( $this->get_option_group() ) . '"></div>';
-		$this->console( WP_ENVIRONMENT_TYPE );
 	}
 }

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -43,16 +43,30 @@ class AbtActivateTest extends TestCase {
 
 	/**
 	 * TEST: check_environment
+	 *
+	 * @testWith [ "development", false ]
+	 *           [ "local", false ]
+	 *           [ "production", true ]
+	 *           [ "staging", true ]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @param string $environment Environment type.
+	 * @param bool   $expected    Expected result.
 	 */
-	public function test_check_environment() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+	public function test_check_environment( string $environment, bool $expected ) {
+		$result = apply_filters( 'http_request_args', [ 'sslverify' => $environment ] );
+		define( 'WP_ENVIRONMENT_TYPE', $environment );
+
+		$this->assertSame( $expected, $this->instance->check_environment( $result )['sslverify'] );
 	}
 
 	/**
 	 * TEST: check_abt_options_column_exists
 	 */
 	public function test_check_abt_options_column_exists() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+		$this->markTestIncomplete( 'This test is incomplete . ' );
 	}
 
 	/**

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -49,17 +49,13 @@ class AbtActivateTest extends TestCase {
 	 *           [ "production", true ]
 	 *           [ "staging", true ]
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 *
 	 * @param string $environment Environment type.
 	 * @param bool   $expected    Expected result.
 	 */
 	public function test_check_environment( string $environment, bool $expected ) {
-		$result = apply_filters( 'http_request_args', [ 'sslverify' => $environment ] );
-		define( 'WP_ENVIRONMENT_TYPE', $environment );
+		$result = apply_filters( 'http_request_args', [ 'sslverify' => false ] );
 
-		$this->assertSame( $expected, $this->instance->check_environment( $result )['sslverify'] );
+		$this->assertSame( $expected, $this->instance->check_environment( $result, $environment )['sslverify'] );
 	}
 
 	/**

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -48,14 +48,22 @@ class AbtActivateTest extends TestCase {
 	 *           [ "local", false ]
 	 *           [ "production", true ]
 	 *           [ "staging", true ]
+	 *           [ null, null ]
 	 *
 	 * @param string $environment Environment type.
 	 * @param bool   $expected    Expected result.
 	 */
-	public function test_check_environment( string $environment, bool $expected ) {
+	public function test_check_environment( ?string $environment, ?bool $expected ) {
 		$result = apply_filters( 'http_request_args', [ 'sslverify' => false ] );
 
-		$this->assertSame( $expected, $this->instance->check_environment( $result, $environment )['sslverify'] );
+		if ( ! is_null( $environment ) ) {
+			$this->assertSame( $expected, $this->instance->check_environment( $result, $environment )['sslverify'] );
+		} else {
+			$this->assertSame(
+				in_array( wp_get_environment_type(), [ 'production', 'staging' ], true ),
+				$this->instance->check_environment( args: $result )['sslverify']
+			);
+		}
 	}
 
 	/**

--- a/tests/AbtAddAdminBarTest.php
+++ b/tests/AbtAddAdminBarTest.php
@@ -101,8 +101,23 @@ class AbtAddAdminBarTest extends TestCase {
 
 	/**
 	 * TEST: add_theme_support_link()
+	 *
+	 * @testWith [ "abt_theme_support", "abt" ]
+	 *           [ "official", "abt_theme_support" ]
+	 *           [ "manual", "abt_theme_support" ]
+	 *           [ "forum", "abt_theme_support" ]
+	 *
+	 * @param string $id     node id.
+	 * @param string $parent node parent.
 	 */
-	public function test_add_theme_support_link() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+	public function test_add_theme_support_link( string $id, string $parent ) {
+		$wp_admin_bar = new WP_Admin_Bar();
+		$wp_admin_bar->initialize();
+
+		switch_theme( 'cocoon-master' );
+		$this->instance->add_theme_support_link( $wp_admin_bar );
+
+		$this->assertArrayHasKey( $id, $wp_admin_bar->get_nodes() );
+		$this->assertSame( $parent, $wp_admin_bar->get_node( $id )->parent );
 	}
 }

--- a/tests/AbtAdminPageTest.php
+++ b/tests/AbtAdminPageTest.php
@@ -39,7 +39,22 @@ class AbtAdminPageTest extends TestCase {
 	 * TEST: add_menu()
 	 */
 	public function test_add_menu() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+		$abt_base                 = new Abt_Base();
+		$abt_base_get_plugin_name = new ReflectionMethod( $abt_base, 'get_plugin_name' );
+		$abt_base_get_plugin_name->setAccessible( true );
+
+		$abt_base_add_prefix = new ReflectionMethod( $abt_base, 'add_prefix' );
+		$abt_base_add_prefix->setAccessible( true );
+
+		$expected = add_options_page(
+			$abt_base_get_plugin_name->invoke( $abt_base ),
+			$abt_base_get_plugin_name->invoke( $abt_base ),
+			'administrator',
+			'admin-bar-tools',
+			$abt_base_add_prefix->invoke( $abt_base, 'settings' ),
+		);
+
+		$this->assertSame( 'admin_page_admin-bar-tools', $expected );
 	}
 
 	/**


### PR DESCRIPTION
- refs #380 add arg type
- refs #380 add environment_type -> arg
- refs #380 fix sslverify -> use false, add 2nd arg
- refs #380 remove unused output
- refs #380 add use default WP_ENVIRONMENT_TYPE test
- refs #380 add environment_type
- refs #380 fix implementation test_add_menu
- refs #380 fix return type, add execution result of add_options_page function
- refs #380 fix implementation test_add_theme_support_link method
- refs #393 initial commit
- refs #393 add composite -> use cache, npm ci
- refs #393 add composite -> use cache, composer install
- refs #393 fix use compsite -> node_modules_dependencies, vendor-dependencies
- refs #393 add composite -> setup node.js
- refs #393 fix use composite -> Setup Node.js
