### PR TITLE
394 fix check abt options column exists method

### DIFF
--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -64,13 +64,6 @@ class Abt_Activate extends Abt_Base {
 	}
 
 	/**
-	 * Method to check if abt_options exists.
-	 */
-	private function is_abt_options(): bool {
-		return $this->get_abt_options() ? true : false;
-	}
-
-	/**
 	 * Method that compares the VERSION of abt_options with the VERSION value of Abt_Base.
 	 *
 	 * @param string $abt_options_version abt_options version.

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -43,6 +43,27 @@ class Abt_Activate extends Abt_Base {
 	}
 
 	/**
+	 * Method to add missing items to abt_options.
+	 */
+	public function update_abt_options() {
+		$abt_options = $this->get_abt_options();
+
+		if ( ! $abt_options ) {
+			$this->register_options();
+		} elseif ( $this->is_abt_version( $abt_options['version'] ) ) {
+			foreach ( self::OPTIONS_KEY as $key_name ) {
+				if ( ! array_key_exists( $key_name, $abt_options ) ) {
+					if ( 'theme_support' === $key_name ) {
+						$abt_options[ $key_name ] = true;
+					}
+				}
+			}
+
+			$this->set_abt_options( $abt_options );
+		}
+	}
+
+	/**
 	 * Check abt_options column exists.
 	 */
 	public function check_abt_options_column_exists() {

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -66,6 +66,13 @@ class Abt_Activate extends Abt_Base {
 	}
 
 	/**
+	 * Method to check if abt_options exists.
+	 */
+	private function is_abt_options(): bool {
+		return $this->get_abt_options() ? true : false;
+	}
+
+	/**
 	 * Register wp_options column.
 	 */
 	public function register_options(): void {

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -64,29 +64,6 @@ class Abt_Activate extends Abt_Base {
 	}
 
 	/**
-	 * Check abt_options column exists.
-	 */
-	public function check_abt_options_column_exists() {
-		$abt_options = $this->get_abt_options();
-		$this->create_items();
-
-		if ( ! $abt_options ) {
-			$this->register_options();
-		} elseif ( $this->get_version() !== $abt_options['version'] ) {
-			foreach ( self::OPTIONS_KEY as $key_name ) {
-				if ( ! array_key_exists( $key_name, $abt_options ) ) {
-					if ( 'theme_support' === $key_name ) {
-						$abt_options[ $key_name ] = true;
-					}
-				}
-			}
-
-			$this->set_abt_options( $abt_options );
-		}
-
-	}
-
-	/**
 	 * Method to check if abt_options exists.
 	 */
 	private function is_abt_options(): bool {

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -23,7 +23,7 @@ class Abt_Activate extends Abt_Base {
 	 */
 	public function __construct() {
 		register_activation_hook( $this->get_plugin_path(), [ $this, 'register_options' ] );
-		add_action( 'init', [ $this, 'check_abt_options_column_exists' ], 10 );
+		add_action( 'init', [ $this, 'update_abt_options' ], 10 );
 		add_filter( 'http_request_args', [ $this, 'check_environment' ], 0, 1 );
 	}
 

--- a/class/class-abt-activate.php
+++ b/class/class-abt-activate.php
@@ -73,6 +73,15 @@ class Abt_Activate extends Abt_Base {
 	}
 
 	/**
+	 * Method that compares the VERSION of abt_options with the VERSION value of Abt_Base.
+	 *
+	 * @param string $abt_options_version abt_options version.
+	 */
+	private function is_abt_version( string $abt_options_version ): bool {
+		return $this->get_version() === $abt_options_version ? true : false;
+	}
+
+	/**
 	 * Register wp_options column.
 	 */
 	public function register_options(): void {

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -74,6 +74,20 @@ class AbtActivateTest extends TestCase {
 	}
 
 	/**
+	 * TEST: is_abt_options
+	 */
+	public function test_is_abt_options() {
+		$is_abt_options = new ReflectionMethod( $this->instance, 'is_abt_options' );
+		$is_abt_options->setAccessible( true );
+
+		$this->assertTrue( $is_abt_options->invoke( $this->instance ) );
+
+		delete_option( 'abt_options' );
+
+		$this->assertFalse( $is_abt_options->invoke( $this->instance ) );
+	}
+
+	/**
 	 * TEST: register_options()
 	 *
 	 * @testWith [ "items", "" ]

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -67,6 +67,44 @@ class AbtActivateTest extends TestCase {
 	}
 
 	/**
+	 * TEST: update_abt_options
+	 */
+	public function test_update_abt_options() {
+		$abt_base                 = new Abt_Base();
+		$abt_base_get_abt_options = new ReflectionMethod( $abt_base, 'get_abt_options' );
+		$abt_base_get_abt_options->setAccessible( true );
+
+		$get_abt_options = function() use ( $abt_base_get_abt_options ) {
+			return $abt_base_get_abt_options->invoke( $this->instance );
+		};
+
+		$delete_abt_options = function() {
+			delete_option( 'abt_options' );
+		};
+
+		if ( $get_abt_options() ) {
+			$delete_abt_options();
+		}
+
+		$this->assertTrue( empty( $get_abt_options() ) );
+
+		$this->instance->update_abt_options();
+
+		$this->assertTrue( ! empty( $get_abt_options() ) );
+
+		$abt_options            = $get_abt_options();
+		$abt_options['version'] = '0.0.0';
+		unset( $abt_options['theme_support'] );
+
+		$this->assertArrayNotHasKey( 'theme_support', $abt_options );
+
+		$this->instance->update_abt_options();
+
+		$this->assertNotSame( $abt_options['version'], $get_abt_options()['version'] );
+		$this->assertArrayHasKey( 'theme_support', $get_abt_options() );
+	}
+
+	/**
 	 * TEST: check_abt_options_column_exists
 	 */
 	public function test_check_abt_options_column_exists() {

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -88,6 +88,20 @@ class AbtActivateTest extends TestCase {
 	}
 
 	/**
+	 * TEST: is_abt_version
+	 */
+	public function test_is_abt_version() {
+		$is_plugin_version = new ReflectionMethod( $this->instance, 'is_abt_version' );
+		$is_plugin_version->setAccessible( true );
+
+		$abt_base                 = new Abt_Base();
+		$abt_base_get_abt_options = new ReflectionMethod( $abt_base, 'get_abt_options' );
+		$abt_base_get_abt_options->setAccessible( true );
+
+		$this->assertTrue( $is_plugin_version->invoke( $this->instance, $abt_base_get_abt_options->invoke( $abt_base )['version'] ) );
+	}
+
+	/**
 	 * TEST: register_options()
 	 *
 	 * @testWith [ "items", "" ]

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -105,20 +105,6 @@ class AbtActivateTest extends TestCase {
 	}
 
 	/**
-	 * TEST: is_abt_options
-	 */
-	public function test_is_abt_options() {
-		$is_abt_options = new ReflectionMethod( $this->instance, 'is_abt_options' );
-		$is_abt_options->setAccessible( true );
-
-		$this->assertTrue( $is_abt_options->invoke( $this->instance ) );
-
-		delete_option( 'abt_options' );
-
-		$this->assertFalse( $is_abt_options->invoke( $this->instance ) );
-	}
-
-	/**
 	 * TEST: is_abt_version
 	 */
 	public function test_is_abt_version() {

--- a/tests/AbtActivateTest.php
+++ b/tests/AbtActivateTest.php
@@ -105,13 +105,6 @@ class AbtActivateTest extends TestCase {
 	}
 
 	/**
-	 * TEST: check_abt_options_column_exists
-	 */
-	public function test_check_abt_options_column_exists() {
-		$this->markTestIncomplete( 'This test is incomplete . ' );
-	}
-
-	/**
 	 * TEST: is_abt_options
 	 */
 	public function test_is_abt_options() {


### PR DESCRIPTION
- refs #394 add implementesion test -> test_is_abt_options
- refs #394 add is_abt_options method
- refs #394 add implementesion test -> test_is_abt_version
- refs #394 add is_abt_version method
- refs #394 add implementesion test -> test_update_abt_options method
- refs #394 add update_abt_options method
- refs #394 fix add_action -> use update_abt_options method
- refs #394 remove unused test_check_abt_options_column_exists method
- refs #394 remove unused check_abt_options_column_exists method
- refs #394 remove unused is_abt_options method
- refs #394 remove unused test_is_abt_options method
